### PR TITLE
Fix stacked chart and returns card [render preview]

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -319,7 +319,7 @@ def update_cards(start_date, end_date, selected_countries):
     # Calculate total returns
     returns = filtered_df[filtered_df['Revenue'] < 0]
     total_returns_value = html.Span(
-        f"£{returns['Revenue'].sum():,.2f}",
+        f"-£{-1*returns['Revenue'].sum():,.2f}",
         style={'color': '#9A2A2A', 'fontWeight': 'bold'}  
     )
 

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -107,7 +107,7 @@ def plot_stacked_chart(start_date, end_date, selected_countries):
     ]
     ).properties(
         title='Revenue Stacked Chart',
-        width=100,
+        width=200,
         height=300
     )
 


### PR DESCRIPTION
- centre align stacked revenue chart
- move -ve sign in returns card before pound symbol